### PR TITLE
Fix | Added the warning message to the resource bundle

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerResource.java
@@ -534,5 +534,7 @@ public final class SQLServerResource extends ListResourceBundle {
             {"R_unknownUTF8SupportValue", "Unknown value for UTF8 support."},
             {"R_illegalWKT", "Illegal Well-Known text. Please make sure Well-Known text is valid."},
             {"R_illegalTypeForGeometry", "{0} is not supported for Geometry."},
-            {"R_illegalWKTposition", "Illegal character in Well-Known text at position {0}."},};
+            {"R_illegalWKTposition", "Illegal character in Well-Known text at position {0}."},
+            {"R_propertyNotSupported",
+                    "The Microsoft SQL Server JDBC Driver currently does not support the property: {0}"},};
 }

--- a/src/main/java/com/microsoft/sqlserver/jdbc/osgi/SQLServerDataSourceFactory.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/osgi/SQLServerDataSourceFactory.java
@@ -6,7 +6,9 @@ package com.microsoft.sqlserver.jdbc.osgi;
 
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.util.Locale;
 import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.logging.Level;
 
 import javax.activation.DataSource;
@@ -22,15 +24,16 @@ import com.microsoft.sqlserver.jdbc.SQLServerXADataSource;
 
 
 /**
- * Implementation of the Data Service Specification for JDBC™ Technology
- * 
- * see https://osgi.org/specification/osgi.cmpn/7.0.0/service.jdbc.html
+ * Implementation of the Data Service Specification for JDBC™ Technology. Refer to the OSGI 7.0.0 specifications for
+ * more details.
  */
 public class SQLServerDataSourceFactory implements DataSourceFactory {
 
     private static java.util.logging.Logger osgiLogger = java.util.logging.Logger
             .getLogger("com.microsoft.sqlserver.jdbc.osgi.SQLServerDataSourceFactory");
-    private static String NOT_SUPPORTED_MSG = "The Microsoft SQL Server JDBC Driver currently does not support the property: {0}";
+    private static final String NOT_SUPPORTED_MSG = ResourceBundle
+            .getBundle("com.microsoft.sqlserver.jdbc.SQLServerResource", Locale.getDefault())
+            .getString("R_propertyNotSupported");
 
     @Override
     public javax.sql.DataSource createDataSource(Properties props) throws SQLException {
@@ -60,7 +63,7 @@ public class SQLServerDataSourceFactory implements DataSourceFactory {
     }
 
     /**
-     * Setups the basic properties for {@link DataSource}s
+     * Sets up the basic properties for {@link DataSource}s
      */
     private void setup(SQLServerDataSource source, Properties props) {
         if (props == null) {
@@ -99,7 +102,7 @@ public class SQLServerDataSourceFactory implements DataSourceFactory {
     }
 
     /**
-     * Setup the basic and extended properties for {@link XADataSource}s and {@link ConnectionPoolDataSource}s
+     * Sets up the basic and extended properties for {@link XADataSource}s and {@link ConnectionPoolDataSource}s
      */
     private void setupXSource(SQLServerConnectionPoolDataSource source, Properties props) {
         if (props == null) {


### PR DESCRIPTION
Added the new message to SQLServerResource for better management and source control. Necessary for the message to be translated. Also removed the link from the javadoc and replaced it with a (hopefully) helpful nudge towards the documentation. 